### PR TITLE
Add additional string formatting conversion options

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,8 +4,8 @@
    contain the root `toctree` directive.
 
 .. meta::
-   description: Trollsift project, modules for formatting, parsing and filtering satellite granule file names
-   keywords: Python, pytroll, format, parse, filter, string
+   :description: Trollsift project, modules for formatting, parsing and filtering satellite granule file names
+   :keywords: Python, pytroll, format, parse, filter, string
 
 Welcome to the trollsift documentation!
 =========================================
@@ -26,7 +26,6 @@ Contents
 
    installation
    usage
-   examples
    api
 
 Indices and tables

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -1,9 +1,3 @@
-
-.. .. sectnum::
-..   :depth: 4
-..   :start: 2
-..   :suffix: .
-
 .. _string-format: https://docs.python.org/2/library/string.html#format-string-syntax
 
 Usage
@@ -44,6 +38,14 @@ a new file name,
   >>> p.compose(data)
   '/somedir/otherdir/hrpt_noaa16_20120101_0101_69022.l1b'
 
+In addition to python's builtin string formatting functionality trollsift also
+provides extra conversion options such as making all characters lowercase:
+
+  >>> my_parser = Parser("{platform_name:l}")
+  >>> my_parser.compose({'platform_name': 'NPP'})
+  'npp'
+
+For all of the options see :class:`~trollsift.parser.StringFormatter`.
 
 standalone parse and compose
 +++++++++++++++++++++++++++++++++++++++++

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ release=1
 
 [bdist_wheel]
 universal=1
+
+[flake8]
+max-line-length = 120

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -104,12 +104,12 @@ class StringFormatter(string.Formatter):
 
     - c: Make capitalized version of string (first character upper case, all lowercase after that) by executing the
       parameter's `.capitalize()` method.
-    - h: A combination of 'R' and 'l'.
-    - H: A combination of 'R' and 'u'.
     - l: Make all characters lowercase by executing the parameter's `.lower()` method.
     - R: Remove all separators from the parameter including '-', '_', ' ', and ':'.
     - t: Title case the string by executing the parameter's `.title()` method.
     - u: Make all characters uppercase by executing the parameter's `.upper()` method.
+    - h: A combination of 'R' and 'l'.
+    - H: A combination of 'R' and 'u'.
 
     """
     CONV_FUNCS = {

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -103,11 +103,11 @@ class StringFormatter(string.Formatter):
     "TO_UPPER_to_lowercase"
 
     - c: Make capitalized version of string (first character upper case, all lowercase after that) by executing the
-         parameter's `.capitalize()` method.
+      parameter's `.capitalize()` method.
     - h: A combination of 'R' and 'l'.
     - H: A combination of 'R' and 'u'.
     - l: Make all characters lowercase by executing the parameter's `.lower()` method.
-    - R: Remove all separators from the parameter including '-', '_', and ':'.
+    - R: Remove all separators from the parameter including '-', '_', ' ', and ':'.
     - t: Title case the string by executing the parameter's `.title()` method.
     - u: Make all characters uppercase by executing the parameter's `.upper()` method.
 

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -285,6 +285,35 @@ class TestParser(unittest.TestCase):
         self.assertFalse(is_one2one(
             "/somedir/{directory}/somedata_{platform:4s}_{time:%Y%d%m-%H%M}_{orbit:d}.l1b"))
 
+    def test_compose(self):
+        """Test the compose method's custom conversion options."""
+        from trollsift import compose
+        key_vals = {'a': 'this Is A-Test b_test c test'}
+
+        new_str = compose("{a!c}", key_vals)
+        self.assertEqual(new_str, 'This is a-test b_test c test')
+        new_str = compose("{a!h}", key_vals)
+        self.assertEqual(new_str, 'thisisatestbtestctest')
+        new_str = compose("{a!H}", key_vals)
+        self.assertEqual(new_str, 'THISISATESTBTESTCTEST')
+        new_str = compose("{a!l}", key_vals)
+        self.assertEqual(new_str, 'this is a-test b_test c test')
+        new_str = compose("{a!R}", key_vals)
+        self.assertEqual(new_str, 'thisIsATestbtestctest')
+        new_str = compose("{a!t}", key_vals)
+        self.assertEqual(new_str, 'This Is A-Test B_Test C Test')
+        new_str = compose("{a!u}", key_vals)
+        self.assertEqual(new_str, 'THIS IS A-TEST B_TEST C TEST')
+        # builtin repr
+        new_str = compose("{a!r}", key_vals)
+        self.assertEqual(new_str, '\'this Is A-Test b_test c test\'')
+        # no formatting
+        new_str = compose("{a}", key_vals)
+        self.assertEqual(new_str, 'this Is A-Test b_test c test')
+        # bad formatter
+        self.assertRaises(ValueError, compose, "{a!X}", key_vals)
+        self.assertEqual(new_str, 'this Is A-Test b_test c test')
+
     def assertDictEqual(self, a, b):
         for key in a:
             self.assertTrue(key in b)


### PR DESCRIPTION
This PR adds a custom string formatter class to the parser module. This custom class lets a user provide a few new conversions to perform common operations needed by me and probably other satpy users. Copying the docstring of the class here:

```
   """Custom string formatter class for basic strings.

    This formatter adds a few special conversions for assisting with common
    trollsift situations like making a parameter lowercase or removing
    hyphens. The added conversions are listed below and can be used in a
    format string by prefixing them with an `!` like so:

    >>> fstr = "{!u}_{!l}"
    >>> formatter = StringFormatter()
    >>> formatter.format(fstr, "to_upper", "To_LowerCase")
    "TO_UPPER_to_lowercase"

    - c: Make capitalized version of string (first character upper case, all lowercase after that) by executing the
         parameter's `.capitalize()` method.
    - h: A combination of 'R' and 'l'.
    - H: A combination of 'R' and 'u'.
    - l: Make all characters lowercase by executing the parameter's `.lower()` method.
    - R: Remove all separators from the parameter including '-', '_', and ':'.
    - t: Title case the string by executing the parameter's `.title()` method.
    - u: Make all characters uppercase by executing the parameter's `.upper()` method.

    """
```