### PR TITLE
Refactor parser to be a little cleaner

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,8 +4,8 @@
    contain the root `toctree` directive.
 
 .. meta::
-   description: Trollsift project, modules for formatting, parsing and filtering satellite granule file names
-   keywords: Python, pytroll, format, parse, filter, string
+   :description: Trollsift project, modules for formatting, parsing and filtering satellite granule file names
+   :keywords: Python, pytroll, format, parse, filter, string
 
 Welcome to the trollsift documentation!
 =========================================
@@ -26,7 +26,6 @@ Contents
 
    installation
    usage
-   examples
    api
 
 Indices and tables

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -1,9 +1,3 @@
-
-.. .. sectnum::
-..   :depth: 4
-..   :start: 2
-..   :suffix: .
-
 .. _string-format: https://docs.python.org/2/library/string.html#format-string-syntax
 
 Usage
@@ -44,6 +38,14 @@ a new file name,
   >>> p.compose(data)
   '/somedir/otherdir/hrpt_noaa16_20120101_0101_69022.l1b'
 
+In addition to python's builtin string formatting functionality trollsift also
+provides extra conversion options such as making all characters lowercase:
+
+  >>> my_parser = Parser("{platform_name:l}")
+  >>> my_parser.compose({'platform_name': 'NPP'})
+  'npp'
+
+For all of the options see :class:`~trollsift.parser.StringFormatter`.
 
 standalone parse and compose
 +++++++++++++++++++++++++++++++++++++++++

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ release=1
 
 [bdist_wheel]
 universal=1
+
+[flake8]
+max-line-length = 120

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -305,18 +305,6 @@ def _convert(convdef, stri):
     return result
 
 
-def _collect_keyvals_from_parsedef(parsedef):
-    """Collect dict keys and values from parsedef."""
-    keys, vals = [], []
-
-    for itm in parsedef:
-        if isinstance(itm, dict):
-            keys.append(list(itm.keys())[0])
-            vals.append(list(itm.values())[0])
-
-    return keys, vals
-
-
 def parse(fmt, stri):
     '''Parse keys and corresponding values from *stri* using format
     described in *fmt* string.

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -103,11 +103,11 @@ class StringFormatter(string.Formatter):
     "TO_UPPER_to_lowercase"
 
     - c: Make capitalized version of string (first character upper case, all lowercase after that) by executing the
-         parameter's `.capitalize()` method.
+      parameter's `.capitalize()` method.
     - h: A combination of 'R' and 'l'.
     - H: A combination of 'R' and 'u'.
     - l: Make all characters lowercase by executing the parameter's `.lower()` method.
-    - R: Remove all separators from the parameter including '-', '_', and ':'.
+    - R: Remove all separators from the parameter including '-', '_', ' ', and ':'.
     - t: Title case the string by executing the parameter's `.title()` method.
     - u: Make all characters uppercase by executing the parameter's `.upper()` method.
 

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -138,20 +138,6 @@ class StringFormatter(string.Formatter):
 formatter = StringFormatter()
 
 
-def _extract_parsedef(fmt):
-    """Retrieve parse definition from the format string `fmt`."""
-    parsedef = []
-    convdef = {}
-    for literal_text, field_name, format_spec, conversion in formatter.parse(fmt):
-        if literal_text:
-            parsedef.append(literal_text)
-        if field_name is None:
-            continue
-        parsedef.append({field_name: format_spec or None})
-        convdef[field_name] = format_spec
-    return parsedef, convdef
-
-
 # taken from https://docs.python.org/3/library/re.html#simulating-scanf
 spec_regexes = {
     'c': r'.',

--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -51,23 +51,34 @@ class TestParser(unittest.TestCase):
         self.assertEqual(len(a), len(b))
 
 
-class TestParserVIIRSSDR(unittest.TestCase):
-
-    def setUp(self):
-        self.fmt = 'SVI01_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_{source}.h5'
-        self.string = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        self.data = {'platform_shortname': 'npp',
-                     'start_time': dt.datetime(2012, 2, 25, 18, 1, 24, 500000), 'orbit': 1708,
-                     'end_time': dt.datetime(1900, 1, 1, 18, 2, 48, 700000),
-                     'source': 'noaa_ops',
-                     'creation_time': dt.datetime(2012, 2, 26, 0, 21, 30, 255476)}
-        self.p = Parser(self.fmt)
+class TestParserVariousFormats(unittest.TestCase):
 
     def test_parse(self):
-        # Run
-        result = self.p.parse(self.string)
-        # Assert
-        self.assertDictEqual(result, self.data)
+        fmt = 'SVI01_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_{source}.h5'
+        filename = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
+        data = {'platform_shortname': 'npp',
+                'start_time': dt.datetime(2012, 2, 25, 18, 1, 24, 500000), 'orbit': 1708,
+                'end_time': dt.datetime(1900, 1, 1, 18, 2, 48, 700000),
+                'source': 'noaa_ops',
+                'creation_time': dt.datetime(2012, 2, 26, 0, 21, 30, 255476)}
+        p = Parser(fmt)
+        result = p.parse(filename)
+        self.assertDictEqual(result, data)
+
+    def test_parse_iasi_l2(self):
+        fmt = "W_XX-EUMETSAT-{reception_location},{instrument},{long_platform_id}+{processing_location}_C_EUMS_{processing_time:%Y%m%d%H%M%S}_IASI_PW3_02_{platform_id}_{start_time:%Y%m%d-%H%M%S}Z_{end_time:%Y%m%d.%H%M%S}Z.hdf"
+        filename = "W_XX-EUMETSAT-kan,iasi,metopb+kan_C_EUMS_20170920103559_IASI_PW3_02_M01_20170920-102217Z_20170920.102912Z.hdf"
+        data = {'reception_location': 'kan',
+                'instrument': 'iasi',
+                'long_platform_id': 'metopb',
+                'processing_location': 'kan',
+                'processing_time': dt.datetime(2017, 9, 20, 10, 35, 59),
+                'platform_id': 'M01',
+                'start_time': dt.datetime(2017, 9, 20, 10, 22, 17),
+                'end_time': dt.datetime(2017, 9, 20, 10, 29, 12)}
+        p = Parser(fmt)
+        result = p.parse(filename)
+        self.assertDictEqual(result, data)
 
 
 def suite():
@@ -76,5 +87,5 @@ def suite():
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestParser))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestParserVIIRSSDR))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestParserVariousFormats))
     return mysuite

--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -51,10 +51,30 @@ class TestParser(unittest.TestCase):
         self.assertEqual(len(a), len(b))
 
 
+class TestParserVIIRSSDR(unittest.TestCase):
+
+    def setUp(self):
+        self.fmt = 'SVI01_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_{source}.h5'
+        self.string = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
+        self.data = {'platform_shortname': 'npp',
+                     'start_time': dt.datetime(2012, 2, 25, 18, 1, 24, 500000), 'orbit': 1708,
+                     'end_time': dt.datetime(1900, 1, 1, 18, 2, 48, 700000),
+                     'source': 'noaa_ops',
+                     'creation_time': dt.datetime(2012, 2, 26, 0, 21, 30, 255476)}
+        self.p = Parser(self.fmt)
+
+    def test_parse(self):
+        # Run
+        result = self.p.parse(self.string)
+        # Assert
+        self.assertDictEqual(result, self.data)
+
+
 def suite():
     """The suite for test_parser
     """
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestParser))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestParserVIIRSSDR))
     return mysuite

--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -53,7 +53,7 @@ class TestParser(unittest.TestCase):
 
 class TestParserVariousFormats(unittest.TestCase):
 
-    def test_parse(self):
+    def test_parse_viirs_sdr(self):
         fmt = 'SVI01_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_{source}.h5'
         filename = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
         data = {'platform_shortname': 'npp',
@@ -76,6 +76,37 @@ class TestParserVariousFormats(unittest.TestCase):
                 'platform_id': 'M01',
                 'start_time': dt.datetime(2017, 9, 20, 10, 22, 17),
                 'end_time': dt.datetime(2017, 9, 20, 10, 29, 12)}
+        p = Parser(fmt)
+        result = p.parse(filename)
+        self.assertDictEqual(result, data)
+
+    def test_parse_olci_l1b(self):
+        fmt = ("{mission_id:3s}_OL_1_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_"
+               "{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_"
+               "{cycle:3d}_{relative_orbit:3d}_{frame:4d}_{centre:3s}_{platform_mode:1s}_"
+               "{timeliness:2s}_{collection:3s}.SEN3/"
+               "{dataset_name}_radiance.nc")
+        # made up:
+        filename = ("S3A_OL_1_EFR____20180916T090539_"
+                    "20180916T090839_20180916T090539_0001_"
+                    "001_001_0001_CEN_M_"
+                    "AA_AAA.SEN3/"
+                    "Oa21_radiance.nc")
+        data = {'mission_id': 'S3A',
+                'datatype_id': 'EFR',
+                'start_time': dt.datetime(2018, 9, 16, 9, 5, 39),
+                'end_time': dt.datetime(2018, 9, 16, 9, 8, 39),
+                'creation_time': dt.datetime(2018, 9, 16, 9, 5, 39),
+                'duration': 1,
+                'cycle': 1,
+                'relative_orbit': 1,
+                'frame': 1,
+                'centre': 'CEN',
+                'platform_mode': 'M',
+                'timeliness': 'AA',
+                'collection': 'AAA',
+                'dataset_name': 'Oa21',
+                }
         p = Parser(fmt)
         result = p.parse(filename)
         self.assertDictEqual(result, data)

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -197,21 +197,6 @@ class TestParser(unittest.TestCase):
         # Assert
         self.assertEqual(result, 'hrpt_noaa??_????????_????_*.l1b')
 
-    def test_collect_keyvals_from_parsedef(self):
-        # Run
-        keys, vals = _collect_keyvals_from_parsedef(['/somedir/',
-                                                     {'directory': None},
-                                                     '/hrpt_',
-                                                     {'platform': '4s'},
-                                                     {'platnum': '2s'}, '_',
-                                                     {'time': '%Y%m%d_%H%M'},
-                                                     '_', {'orbit': '05d'},
-                                                     '.l1b'])
-        # Assert
-        self.assertEqual(keys, ['directory', 'platform',
-                                'platnum', 'time', 'orbit'])
-        self.assertEqual(vals, [None, '4s', '2s', '%Y%m%d_%H%M', '05d'])
-
     def test_validate(self):
         # These cases are True
         self.assertTrue(

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -1,7 +1,7 @@
 import unittest
 import datetime as dt
 
-from trollsift.parser import _extract_parsedef, regex_formatter
+from trollsift.parser import get_convert_dict, regex_formatter
 from trollsift.parser import _convert
 from trollsift.parser import parse, globify, validate, is_one2one
 
@@ -16,16 +16,17 @@ class TestParser(unittest.TestCase):
         self.string3 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_69022"
         self.string4 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_69022"
 
-    def test_extract_parsedef(self):
+    def test_get_convert_dict(self):
         # Run
-        result, dummy = _extract_parsedef(self.fmt)
+        result = get_convert_dict(self.fmt)
         # Assert
-        self.assertItemsEqual(result,
-                              ['/somedir/', {'directory': None},
-                               '/hrpt_', {'platform': '4s'},
-                               {'platnum': '2s'},
-                               '_', {'time': '%Y%m%d_%H%M'},
-                               '_', {'orbit': '05d'}, '.l1b'])
+        self.assertDictEqual(result, {
+            'directory': '',
+            'platform': '4s',
+            'platnum': '2s',
+            'time': '%Y%m%d_%H%M',
+            'orbit': '05d',
+        })
 
     def test_extract_values(self):
         fmt = "/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:d}.l1b"

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -2,7 +2,7 @@ import unittest
 import datetime as dt
 
 from trollsift.parser import _extract_parsedef, regex_formatter
-from trollsift.parser import _convert, _collect_keyvals_from_parsedef
+from trollsift.parser import _convert
 from trollsift.parser import parse, globify, validate, is_one2one
 
 

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -173,7 +173,6 @@ class TestParser(unittest.TestCase):
                                       'segment': '000007',
                                       'start_time': dt.datetime(2015, 6, 5, 17, 0)})
 
-
     def test_globify_simple(self):
         # Run
         result = globify('{a}_{b}.end', {'a': 'a', 'b': 'b'})

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -285,6 +285,35 @@ class TestParser(unittest.TestCase):
         self.assertFalse(is_one2one(
             "/somedir/{directory}/somedata_{platform:4s}_{time:%Y%d%m-%H%M}_{orbit:d}.l1b"))
 
+    def test_compose(self):
+        """Test the compose method's custom conversion options."""
+        from trollsift import compose
+        key_vals = {'a': 'this Is A-Test b_test c test'}
+
+        new_str = compose("{a!c}", key_vals)
+        self.assertEqual(new_str, 'This is a-test b_test c test')
+        new_str = compose("{a!h}", key_vals)
+        self.assertEqual(new_str, 'thisisatestbtestctest')
+        new_str = compose("{a!H}", key_vals)
+        self.assertEqual(new_str, 'THISISATESTBTESTCTEST')
+        new_str = compose("{a!l}", key_vals)
+        self.assertEqual(new_str, 'this is a-test b_test c test')
+        new_str = compose("{a!R}", key_vals)
+        self.assertEqual(new_str, 'thisIsATestbtestctest')
+        new_str = compose("{a!t}", key_vals)
+        self.assertEqual(new_str, 'This Is A-Test B_Test C Test')
+        new_str = compose("{a!u}", key_vals)
+        self.assertEqual(new_str, 'THIS IS A-TEST B_TEST C TEST')
+        # builtin repr
+        new_str = compose("{a!r}", key_vals)
+        self.assertEqual(new_str, '\'this Is A-Test b_test c test\'')
+        # no formatting
+        new_str = compose("{a}", key_vals)
+        self.assertEqual(new_str, 'this Is A-Test b_test c test')
+        # bad formatter
+        self.assertRaises(ValueError, compose, "{a!X}", key_vals)
+        self.assertEqual(new_str, 'this Is A-Test b_test c test')
+
     def assertDictEqual(self, a, b):
         for key in a:
             self.assertTrue(key in b)


### PR DESCRIPTION
This PR is based off of #6 

It adds a GlobifyFormatter object used by the globify function to split the complicated globify code in to a "standard" interface.

I'm also working on using these formatter classes to refactor the remainder of the complicated parser logic but it is super complicated so not sure if I'll actually finish it.