### PR TITLE
Fix fill/pad handling in regex formatter

### DIFF
--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -161,6 +161,18 @@ fmt_spec_regex = re.compile(
 
 
 class RegexFormatter(string.Formatter):
+    """String formatter that converts a format string to a regular expression.
+    
+    >>> regex_formatter = RegexFormatter()
+    >>> regex_str = regex_formatter.format('{field_one:5d}_{field_two}')
+
+    Can also be used to extract values from a string given the format spec
+    for that string:
+
+    >>> regex_formatter.extract_values('{field_one:5d}_{field_two}', '12345_sometext')
+    {'field_one': '12345', 'field_two': 'sometext'}
+
+    """
 
     # special string to mark a parameter not being specified
     UNPROVIDED_VALUE = '<trollsift unprovided value>'
@@ -510,9 +522,7 @@ def is_one2one(fmt):
         return False
 
     # run data forward once and back to data
-    print(fmt, data)
     stri = compose(fmt, data)
-    print(fmt, stri)
     data2 = parse(fmt, stri)
     # check if data2 equal to original data
     if len(data) != len(data2):

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -291,20 +291,16 @@ def _convert(convdef, stri):
     if '%' in convdef:
         result = dt.datetime.strptime(stri, convdef)
     elif 'd' in convdef or 's' in convdef:
-        try:
-            align = convdef[0]
-            if align in [">", "<", "^"]:
-                pad = " "
-            else:
-                align = convdef[1]
-                if align in [">", "<", "^"]:
-                    pad = convdef[0]
-                else:
-                    align = None
-                    pad = None
-        except IndexError:
-            align = None
-            pad = None
+        regex_match = fmt_spec_regex.match(convdef)
+        match_dict = regex_match.groupdict() if regex_match else {}
+        align = match_dict.get('align')
+        pad = match_dict.get('fill')
+        if align:
+            # align character is the last one
+            align = align[-1]
+        if align and align in '<>^' and not pad:
+            pad = ' '
+
         if align == '>':
             stri = stri.lstrip(pad)
         elif align == '<':


### PR DESCRIPTION
My refactored parse function which uses regular expressions had a hidden bug that only showed up at random moments based on how `is_one2one` works. I've now added specific tests for this. The case being a width-specified format where the value doesn't fill the entire width:

```python
parse('{:5d}', '  123')
```

My code was requiring 5 digits, not including fill characters.