### PR TITLE
Return _extract_parsedef()

### DIFF
--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -89,6 +89,31 @@ class Parser(object):
         return is_one2one(self.fmt)
 
 
+def _extract_parsedef(fmt):
+    '''Retrieve parse definition from the format string *fmt*.
+    '''
+
+    parsedef = []
+    convdef = {}
+
+    for part1 in fmt.split('}'):
+        part2 = part1.split('{', 1)
+        if part2[0] is not '':
+            parsedef.append(part2[0])
+        if len(part2) > 1 and part2[1] is not '':
+            if ':' in part2[1]:
+                part2 = part2[1].split(':', 1)
+                parsedef.append({part2[0]: part2[1]})
+                convdef[part2[0]] = part2[1]
+            else:
+                reg = re.search('(\{' + part2[1] + '\})', fmt)
+                if reg:
+                    parsedef.append({part2[1]: None})
+                else:
+                    parsedef.append(part2[1])
+    return parsedef, convdef
+
+
 class StringFormatter(string.Formatter):
     """Custom string formatter class for basic strings.
 

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -89,9 +89,17 @@ class Parser(object):
         return is_one2one(self.fmt)
 
 
+def extract_parsedef(fmt):
+    """Retrieve parse definiotons from the format string *fmt*."""
+    return _extract_parsedef(fmt)
+
+
 def _extract_parsedef(fmt):
     '''Retrieve parse definition from the format string *fmt*.
     '''
+    import warnings
+    warnings.warn("'_extract_parsedef()' is deprecated, use 'extract_parsedef'"
+                  " instead", DeprecationWarning)
 
     parsedef = []
     convdef = {}

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -4,6 +4,7 @@ import datetime as dt
 from trollsift.parser import get_convert_dict, regex_formatter
 from trollsift.parser import _convert
 from trollsift.parser import parse, globify, validate, is_one2one
+from trollsift.parser import _extract_parsedef
 
 
 class TestParser(unittest.TestCase):
@@ -15,6 +16,17 @@ class TestParser(unittest.TestCase):
         self.string2 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_00022.l1b"
         self.string3 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_69022"
         self.string4 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_69022"
+
+    def test_extract_parsedef(self):
+        # Run
+        result, dummy = _extract_parsedef(self.fmt)
+        # Assert
+        self.assertEqual(result,
+                            ['/somedir/', {'directory': None},
+                             '/hrpt_', {'platform': '4s'},
+                             {'platnum': '2s'},
+                             '_', {'time': '%Y%m%d_%H%M'},
+                             '_', {'orbit': '05d'}, '.l1b'])
 
     def test_get_convert_dict(self):
         # Run


### PR DESCRIPTION
This PR returns the `_extract_parsedef()` function to `trollsift.parser`, as it is used by `trollflow-sat` and `pytroll-collectors` packages when adjusting timestamps and/or the names used for e.g. the nominal time of the scene in the filename pattern to match the name in the incoming posttroll message.