### PR TITLE
Fix fields being specified multiple times in one pattern

### DIFF
--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -111,6 +111,14 @@ class TestParserVariousFormats(unittest.TestCase):
         result = p.parse(filename)
         self.assertDictEqual(result, data)
 
+    def test_parse_duplicate_fields(self):
+        """Test parsing a pattern that has duplicate fields."""
+        fmt = '{version_number:1s}/filename_with_version_number_{version_number:1s}.tif'
+        filename = '1/filename_with_version_number_1.tif'
+        p = Parser(fmt)
+        result = p.parse(filename)
+        self.assertEqual(result['version_number'], '1')
+
 
 def suite():
     """The suite for test_parser


### PR DESCRIPTION
Fix #11

I couldn't think of a better way of "caching" the field name since fields are handled one at a time.