### PR TITLE
Fix parse accepting strings with trailing characters

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,4 @@
+linters:
+  flake8:
+    python: 3
+    config: setup.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
     os: osx
     language: generic
 install:
-- git clone --depth 1 git://github.com/astropy/ci-helpers.git
+#- git clone --depth 1 git://github.com/astropy/ci-helpers.git
+- git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh
 script:
 - coverage run --source=trollsift setup.py test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,10 @@ environment:
       NUMPY_VERSION: "stable"
 
 install:
-    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+#    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+    - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "activate test"
+    - "conda activate test"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -295,8 +295,19 @@ class RegexFormatter(string.Formatter):
         field_name, value = value
         return self.regex_field(field_name, value, format_spec)
 
-    def extract_values(self, fmt, stri):
+    def extract_values(self, fmt, stri, full_match=True):
+        """Extract information from string matching format.
+
+        Args:
+            fmt (str): Python format string to match against
+            stri (str): String to extract information from
+            full_match (bool): Force the match of the whole string. Default
+                to ``True``.
+
+        """
         regex = self.format(fmt)
+        if full_match:
+            regex = '^' + regex + '$'
         match = re.match(regex, stri)
         if match is None:
             raise ValueError("String does not match pattern.")
@@ -307,9 +318,10 @@ regex_formatter = RegexFormatter()
 
 
 def _get_number_from_fmt(fmt):
-    """
-    Helper function for extract_values,
-    figures out string length from format string.
+    """Helper function for extract_values.
+
+    Figures out string length from format string.
+
     """
     if '%' in fmt:
         # its datetime
@@ -362,10 +374,18 @@ def get_convert_dict(fmt):
     return convdef
 
 
-def parse(fmt, stri):
-    """Parse keys and corresponding values from *stri* using format described in *fmt* string."""
+def parse(fmt, stri, full_match=True):
+    """Parse keys and corresponding values from *stri* using format described in *fmt* string.
+
+    Args:
+        fmt (str): Python format string to match against
+        stri (str): String to extract information from
+        full_match (bool): Force the match of the whole string. Default
+            True.
+
+    """
     convdef = get_convert_dict(fmt)
-    keyvals = regex_formatter.extract_values(fmt, stri)
+    keyvals = regex_formatter.extract_values(fmt, stri, full_match=True)
     for key in convdef.keys():
         keyvals[key] = _convert(convdef[key], keyvals[key])
 

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -41,11 +41,11 @@ class Parser(object):
     def __str__(self):
         return self.fmt
 
-    def parse(self, stri):
+    def parse(self, stri, full_match=True):
         '''Parse keys and corresponding values from *stri* using format
         described in *fmt* string.
         '''
-        return parse(self.fmt, stri)
+        return parse(self.fmt, stri, full_match=full_match)
 
     def compose(self, keyvals):
         '''Return string composed according to *fmt* string and filled
@@ -385,7 +385,7 @@ def parse(fmt, stri, full_match=True):
 
     """
     convdef = get_convert_dict(fmt)
-    keyvals = regex_formatter.extract_values(fmt, stri, full_match=True)
+    keyvals = regex_formatter.extract_values(fmt, stri, full_match=full_match)
     for key in convdef.keys():
         keyvals[key] = _convert(convdef[key], keyvals[key])
 

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -97,6 +97,15 @@ class TestParser(unittest.TestCase):
         fmt = '/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:4d}.l1b'
         self.assertRaises(ValueError, regex_formatter.extract_values, fmt, self.string)
 
+    def test_extract_values_full_match(self):
+        """Test that a string must completely match."""
+        fmt = '{orbit:05d}'
+        val = regex_formatter.extract_values(fmt, '12345')
+        self.assertEqual(val, {'orbit': '12345'})
+        self.assertRaises(ValueError, regex_formatter.extract_values, fmt, '12345abc')
+        val = regex_formatter.extract_values(fmt, '12345abc', full_match=False)
+        self.assertEqual(val, {'orbit': '12345'})
+
     def test_convert_digits(self):
         self.assertEqual(_convert('d', '69022'), 69022)
         self.assertRaises(ValueError, _convert, 'd', '69dsf')


### PR DESCRIPTION
Pointed out by @sfinkens on slack. Parse should not allow trailing characters.

This fixes this by adding `^` and `$` to the regular expression for `extract_values` and allowing it to be turned off with `full_match=False` to the `parse` function.