### PR TITLE
Update git repo in installation instructions

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,7 +16,7 @@ for writing higher level applications and api's for satellite batch processing.
 
 The source code of the package can be found at github, github_
 
-.. _github: https://github.com/pnuu/trollsift
+.. _github: https://github.com/pytroll/trollsift
 
 Contents
 +++++++++

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -9,7 +9,7 @@ Installation
 
 You can download the trollsift source code from github,::
 
-  $ git clone https://github.com/pnuu/trollsift.git
+  $ git clone https://github.com/pytroll/trollsift.git
 
 and then run::
 


### PR DESCRIPTION
In the installation instruction, the git repo URI was referring to trollsift being located in /pnuu/trollsift.git.
Update this to refer to /pytroll/trollsift.git instead.