### PR TITLE
Fix typo in string formatting usage example and drop Python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ env:
   global:
   - PYTHON_VERSION=$PYTHON_VERSION
   - NUMPY_VERSION=stable
-  - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='six coveralls coverage mock'
+  - CONDA_DEPENDENCIES='pytest pytest-cov coveralls coverage mock'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request'
@@ -12,30 +11,26 @@ env:
   - CONDA_CHANNELS='conda-forge'
 matrix:
   include:
-  - env: PYTHON_VERSION=2.7
+  - env: PYTHON_VERSION=3.7
     os: linux
-  - env: PYTHON_VERSION=2.7
-    os: osx
-    language: generic
-  - env: PYTHON_VERSION=3.6
-    os: linux
-  - env: PYTHON_VERSION=3.6
+  - env: PYTHON_VERSION=3.7
     os: osx
     language: generic
 install:
 #- git clone --depth 1 git://github.com/astropy/ci-helpers.git
 - git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh
+- pip install --no-deps -e .
 script:
-- coverage run --source=trollsift setup.py test
+- pytest --cov=trollsift --doctest-glob='*.rst' trollsift/tests doc/source/
 after_success:
-- if [[ $PYTHON_VERSION == 3.6 ]]; then coveralls; fi
+- if [[ $PYTHON_VERSION == 3.7 ]]; then coveralls; fi
 deploy:
   - provider: pypi
     user: dhoese
     password:
       secure: OZ5xq8R4zSo4m1luNUmo2q2jriu5cmSjrRp/2OKyKmuB09SjO4/jxEIzPP6hfgqV5h/m/3uOtYpLXQBeMf0xX0EZqmsOL0BaRQfDNuaxoVEoGBPC/04Zh6567sjDv615awHw6QTIE0Yw891dy3pun+E1yX1zKtQ9hcDKQ3ZFImg=
-    distributions: sdist bdist_wheel
+    distributions: sdist
     skip_existing: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
   - PYTHON_VERSION=$PYTHON_VERSION
   - NUMPY_VERSION=stable
-  - CONDA_DEPENDENCIES='pytest pytest-cov coveralls coverage mock'
+  - CONDA_DEPENDENCIES='pytest pytest-cov coveralls coverage'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,24 +3,18 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "coverage mock"
+    CONDA_DEPENDENCIES: "coverage pytest pytest-cov"
     PIP_DEPENDENCIES: ""
     CONDA_CHANNELS: "conda-forge"
 
   matrix:
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      NUMPY_VERSION: "stable"
-
-    - PYTHON: "C:\\Python36_64"
-      PYTHON_VERSION: "3.6"
+    - PYTHON: "C:\\Python37_64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"
 
 install:
-#    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
-    - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
+    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "conda activate test"
 
@@ -28,7 +22,7 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Build the compiled extension and run the project tests
-  - "%CMD_IN_ENV% python setup.py test"
+  - "%CMD_IN_ENV% pytest --cov=trollsift --doctest-glob='*.rst' trollsift/tests doc/source/"
 
 after_test:
   # If tests are successful, create a whl package for the project.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -7,20 +7,35 @@
 Installation
 ------------
 
-You can download the trollsift source code from github,::
+Trollsift is available from PyPI::
+
+  $ pip install trollsift
+
+Alternatively, you can install it into a conda environment by using the
+conda-forge channel::
+
+  $ conda install -c conda-forge trollsift
+
+Or you can install it directly from the GitHub repository::
+
+  $ pip install git+https://github.com/pytroll/trollsift.git
+
+Developer Installation
+++++++++++++++++++++++
+
+You can download the trollsift source code from github::
 
   $ git clone https://github.com/pytroll/trollsift.git
 
 and then run::
 
-  $ python setup.py install
+  $ pip install -e .
 
 Testing
 ++++++++
 
 To check if your python setup is compatible with trollsift,
-you can run the test suite using nosetests,::
+you can run the test suite using pytest::
 
-  $ cd trollsift
-  $ nosetests -v tests/
+  $ pytest trollsift/tests
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -52,7 +52,7 @@ a new file name,
 In addition to python's builtin string formatting functionality trollsift also
 provides extra conversion options such as making all characters lowercase:
 
-  >>> my_parser = Parser("{platform_name:l}")
+  >>> my_parser = Parser("{platform_name!l}")
   >>> my_parser.compose({'platform_name': 'NPP'})
   'npp'
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -21,9 +21,9 @@ The Parser object holds a format string, allowing us to parse and compose string
   >>> 
   >>> p = Parser("/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:05d}.l1b")
   >>> data = p.parse("/somedir/otherdir/hrpt_noaa16_20140210_1004_69022.l1b")
-  >>> print(data)
+  >>> print(data) # doctest: +NORMALIZE_WHITESPACE
   {'directory': 'otherdir', 'platform': 'noaa', 'platnum': '16',
-  'time': datetime.datetime(2014,02,12,14,12), 'orbit':69022}
+   'time': datetime.datetime(2014, 2, 10, 10, 4), 'orbit': 69022}
 
 Parsing in trollsift is not "greedy". This means that in the case of ambiguous
 patterns it will match the shortest portion of the string possible. For example:
@@ -40,9 +40,15 @@ parsing chose the shorter possible match of "abc".
 
 composing
 ^^^^^^^^^
-The reverse operation is called 'compose', and is equivalent to the Python string
-class format method.  Here we change the time stamp of the data, and write out 
-a new file name,
+The reverse operation is called 'compose', and is equivalent to the Python
+string class format method.  Here we take the filename pattern from earlier,
+change the time stamp of the data, and write out a new file name,
+
+.. doctest::
+   :hide:
+  >>> p = Parser("/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:05d}.l1b")
+  >>> data = p.parse("/somedir/otherdir/hrpt_noaa16_20140210_1004_69022.l1b")
+
 
   >>> from datetime import datetime
   >>> data['time'] = datetime(2012, 1, 1, 1, 1)

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+#
 # Copyright (c) 2014, 2015
-
+#
 # Author(s):
-
+#
 # Panu Lahtinen <panu.lahtinen@fmi.fi>
 # Hróbjartur Thorsteinsson <hroi@vedur.is>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-"""Setup for trollsift.
-"""
+"""Setup for trollsift."""
 from setuptools import setup
 import versioneer
 
@@ -36,7 +34,7 @@ setup(name="trollsift",
       long_description=README,
       author='Panu Lahtinen',
       author_email='panu.lahtinen@fmi.fi',
-      classifiers=["Development Status :: 3 - Alpha",
+      classifiers=["Development Status :: 5 - Production/Stable",
                    "Intended Audience :: Science/Research",
                    "License :: OSI Approved :: GNU General Public License v3 " +
                    "or later (GPLv3+)",
@@ -49,5 +47,4 @@ setup(name="trollsift",
       keywords=["string parsing", "string formatting", "pytroll"],
       zip_safe=False,
       install_requires=[],
-      test_suite='trollsift.tests.suite',
       )

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -1,29 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014, 2015
-
-# Author(s):
-
-# Panu Lahtinen <panu.lahtinen@fmi.fi>
-# Hróbjartur Thorsteinsson <thorsteinssonh@gmail.com>
-
+#
+# Copyright (c) 2014-2020 Trollsift Developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-
-"""Parser class
-"""
+"""Main parsing and formatting functionality."""
 
 import re
 import datetime as dt
@@ -32,8 +24,7 @@ import string
 
 
 class Parser(object):
-    """Parser class
-    """
+    """Class-based interface to parsing and formatting functionality."""
 
     def __init__(self, fmt):
         self.fmt = fmt
@@ -188,7 +179,7 @@ class RegexFormatter(string.Formatter):
     # special string to mark a parameter not being specified
     UNPROVIDED_VALUE = '<trollsift unprovided value>'
     ESCAPE_CHARACTERS = ['\\'] + [x for x in string.punctuation if x not in '\\%']
-    ESCAPE_SETS = [(c, '\{}'.format(c)) for c in ESCAPE_CHARACTERS]
+    ESCAPE_SETS = [(c, '\\' + c) for c in ESCAPE_CHARACTERS]
 
     def __init__(self):
         # hold on to fields we've seen already so we can reuse their

--- a/trollsift/tests/__init__.py
+++ b/trollsift/tests/__init__.py
@@ -1,25 +1,2 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-import sys
-from trollsift.tests import unittests, regressiontests, integrationtests
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-
-def suite():
-    """The global test suite.
-    """
-    mysuite = unittest.TestSuite()
-    mysuite.addTests(unittests.suite())
-    mysuite.addTests(regressiontests.suite())
-    mysuite.addTests(integrationtests.suite())
-
-    return mysuite
-
-
-def load_tests(loader, tests, pattern):
-    return suite()

--- a/trollsift/tests/integrationtests/__init__.py
+++ b/trollsift/tests/integrationtests/__init__.py
@@ -1,40 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014 Panu Lahtinen
-
-# Author(s):
-
-# Panu Lahtinen <panu.lahtinen@fmi.fi>
-
+#
+# Copyright (c) 2014-2020 Panu Lahtinen
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-"""The tests package.
-"""
-
-from . import test_parser
-import unittest
-import doctest
-
-def suite():
-    """The global test suite.
-    """
-    mysuite = unittest.TestSuite()
-    # Use the unittests also
-    mysuite.addTests(test_parser.suite())
-    
-    return mysuite
-
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())
+"""Integration tests for the trollsift package."""

--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2014-2020 Martin Raspaud
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Parser integration tests."""
 import os
 import unittest
 import datetime as dt
@@ -121,13 +139,3 @@ class TestParserVariousFormats(unittest.TestCase):
         p = Parser(fmt)
         result = p.parse(filename)
         self.assertEqual(result['version_number'], '1')
-
-
-def suite():
-    """The suite for test_parser
-    """
-    loader = unittest.TestLoader()
-    mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestParser))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestParserVariousFormats))
-    return mysuite

--- a/trollsift/tests/regressiontests/__init__.py
+++ b/trollsift/tests/regressiontests/__init__.py
@@ -16,18 +16,3 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Regression tests for the trollsift package."""
-from . import test_parser
-import unittest
-
-
-def suite():
-    """The global test suite.
-    """
-    mysuite = unittest.TestSuite()
-    # Use the unittests also
-    mysuite.addTests(test_parser.suite())
-
-    return mysuite
-
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/trollsift/tests/regressiontests/__init__.py
+++ b/trollsift/tests/regressiontests/__init__.py
@@ -1,27 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014 Martin Raspaud
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
+# Copyright (c) 2014-2020 Martin Raspaud
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-"""
-"""
+"""Regression tests for the trollsift package."""
 from . import test_parser
 import unittest
 

--- a/trollsift/tests/regressiontests/test_parser.py
+++ b/trollsift/tests/regressiontests/test_parser.py
@@ -1,27 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014 Martin Raspaud
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
+# Copyright (c) 2014-2020 Martin Raspaud
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-"""
-"""
+"""Parser regression tests."""
 
 import unittest
 import datetime as dt
@@ -37,12 +31,3 @@ class TestParser(unittest.TestCase):
         self.assertEqual(res, {'orbit_number': 29889,
                                'satellite': 'NOAA-19',
                                'start_time': dt.datetime(2014, 11, 26, 10, 12)})
-
-
-def suite():
-    """The suite for test_parser
-    """
-    loader = unittest.TestLoader()
-    mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestParser))
-    return mysuite

--- a/trollsift/tests/unittests/__init__.py
+++ b/trollsift/tests/unittests/__init__.py
@@ -1,40 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014 Panu Lahtinen
-
-# Author(s):
-
-# Panu Lahtinen <panu.lahtinen@fmi.fi>
-
+#
+# Copyright (c) 2014-2020 Panu Lahtinen
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-"""The tests package.
-"""
-
-from . import test_parser
-import unittest
-import doctest
-
-def suite():
-    """The global test suite.
-    """
-    mysuite = unittest.TestSuite()
-    # Use the unittests also
-    mysuite.addTests(test_parser.suite())
-    
-    return mysuite
-
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())
+"""Unit tests for the trollsift package."""

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -320,12 +320,3 @@ class TestParser(unittest.TestCase):
         template = '{band_type:s}_{polarization_extracted}_{unit}_{s1_fname}'
         res_dict = parse(template, fname)
         self.assertEqual(exp, res_dict)
-
-
-def suite():
-    """The suite for test_parser
-    """
-    loader = unittest.TestLoader()
-    mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestParser))
-    return mysuite


### PR DESCRIPTION
Closes #20 

Was a `:` in the docs, should be a `!`.