### PR TITLE
Switch travis tests back to using upstream ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ matrix:
     os: osx
     language: generic
 install:
-#- git clone --depth 1 git://github.com/astropy/ci-helpers.git
-- git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
+- git clone --depth 1 git://github.com/astropy/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh
 - pip install --no-deps -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - EVENT_TYPE='push pull_request'
   - SETUP_CMD='test'
   - CONDA_CHANNELS='conda-forge'
+  - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
   - env: PYTHON_VERSION=3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     CONDA_DEPENDENCIES: "coverage pytest pytest-cov"
     PIP_DEPENDENCIES: ""
     CONDA_CHANNELS: "conda-forge"
+    CONDA_CHANNEL_PRIORITY: "strict"
 
   matrix:
     - PYTHON: "C:\\Python37_64"


### PR DESCRIPTION
Noticed I was still using my old custom branch which we switched to when things were getting weird with ci-helpers. Things have been good for a while now so we should switch back.