### PR TITLE
Add lru_cache to parsing for improved performance

### DIFF
--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -21,6 +21,7 @@ import re
 import datetime as dt
 import random
 import string
+from functools import lru_cache
 
 
 class Parser(object):
@@ -187,6 +188,7 @@ class RegexFormatter(string.Formatter):
         self._cached_fields = {}
         super(RegexFormatter, self).__init__()
 
+    @lru_cache()
     def format(*args, **kwargs):
         try:
             # super() doesn't seem to work here
@@ -366,6 +368,8 @@ def _convert(convdef, stri):
     return result
 
 
+
+@lru_cache()
 def get_convert_dict(fmt):
     """Retrieve parse definition from the format string `fmt`."""
     convdef = {}
@@ -579,3 +583,14 @@ def is_one2one(fmt):
             return False
     # all checks passed, so just return True
     return True
+
+
+def purge():
+    """Clear internal caches.
+    
+    Not needed normally, but can be used to force cache clear when memory
+    is very limited.
+    
+    """
+    regex_formatter.format.cache_clear()
+    get_convert_dict.cache_clear()

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -368,7 +368,6 @@ def _convert(convdef, stri):
     return result
 
 
-
 @lru_cache()
 def get_convert_dict(fmt):
     """Retrieve parse definition from the format string `fmt`."""
@@ -587,10 +586,10 @@ def is_one2one(fmt):
 
 def purge():
     """Clear internal caches.
-    
+
     Not needed normally, but can be used to force cache clear when memory
     is very limited.
-    
+
     """
     regex_formatter.format.cache_clear()
     get_convert_dict.cache_clear()

--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -40,6 +40,18 @@ class TestParser(unittest.TestCase):
         # Assert
         self.assertDictEqual(result, self.data)
 
+    def test_cache_clear(self):
+        """Test we can clear the internal cache properly"""
+        from trollsift.parser import purge
+        from trollsift.parser import regex_formatter
+        # Run
+        result = self.p.parse(self.string)
+        # Assert
+        self.assertDictEqual(result, self.data)
+        assert regex_formatter.format.cache_info()[-1] != 0
+        purge()
+        assert regex_formatter.format.cache_info()[-1] == 0
+
     def test_compose(self):
         # Run
         result = self.p.compose(self.data)


### PR DESCRIPTION
This adds caching using the standard library's `functools.lru_cache` to the `get_convert_dict` function and the `RegexFormatter.format` method. These are both used during `parse` and only require the `fmt` and are therefore super easy/efficient to cache. So in the common case (especially Satpy) where we have a single pattern and are checking many other strings against it, this will have a huge impact. In https://github.com/pytroll/satpy/pull/1178, I noticed this change (with ~5600 test strings and 20 format strings) improved my performance from ~4s to ~2.8s.

This PR also adds a `purge` function which allows the user to clear these caches with one single function. However, the default for `lru_cache` that we are using is 128 items which really isn't that many so I don't think this should ever be needed.