### PR TITLE
Fix parsing of fixed point numbers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@ The following people have made contributions to this project:
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
 - [Hrobjartur Thorsteinsson (thorsteinssonh)](https://github.com/thorsteinssonh)
+- [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens)

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setup(name="trollsift",
       keywords=["string parsing", "string formatting", "pytroll"],
       zip_safe=False,
       install_requires=[],
+      tests_require=['pytest']
       )

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -396,8 +396,8 @@ def _strip_padding(convdef, stri):
     """Strip padding from the given string.
 
     Args:
+        convdef: Conversion definition (indicates the padding)
         stri: String to be modified
-        convdef: Corresponding conversion definition (indicates the padding)
     """
     regex_match = fmt_spec_regex.match(convdef)
     match_dict = regex_match.groupdict() if regex_match else {}

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -380,23 +380,7 @@ def _convert(convdef, stri):
     if '%' in convdef:
         result = dt.datetime.strptime(stri, convdef)
     elif 'd' in convdef or 's' in convdef or is_fixed_point:
-        regex_match = fmt_spec_regex.match(convdef)
-        match_dict = regex_match.groupdict() if regex_match else {}
-        align = match_dict.get('align')
-        pad = match_dict.get('fill')
-        if align:
-            # align character is the last one
-            align = align[-1]
-        if align and align in '<>^' and not pad:
-            pad = ' '
-
-        if align == '>':
-            stri = stri.lstrip(pad)
-        elif align == '<':
-            stri = stri.rstrip(pad)
-        elif align == '^':
-            stri = stri.strip(pad)
-
+        stri = _strip_padding(convdef, stri)
         if 'd' in convdef:
             result = int(stri)
         elif is_fixed_point:
@@ -407,6 +391,30 @@ def _convert(convdef, stri):
         result = stri
     return result
 
+
+def _strip_padding(convdef, stri):
+    """Strip padding from the given string.
+
+    Args:
+        stri: String to be modified
+        convdef: Corresponding conversion definition (indicates the padding)
+    """
+    regex_match = fmt_spec_regex.match(convdef)
+    match_dict = regex_match.groupdict() if regex_match else {}
+    align = match_dict.get('align')
+    pad = match_dict.get('fill')
+    if align:
+        # align character is the last one
+        align = align[-1]
+    if align and align in '<>^' and not pad:
+        pad = ' '
+    if align == '>':
+        stri = stri.lstrip(pad)
+    elif align == '<':
+        stri = stri.rstrip(pad)
+    elif align == '^':
+        stri = stri.strip(pad)
+    return stri
 
 @lru_cache()
 def get_convert_dict(fmt):

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -274,7 +274,6 @@ class TestParser(unittest.TestCase):
 
     def test_compose(self):
         """Test the compose method's custom conversion options."""
-        from trollsift import compose
         key_vals = {'a': 'this Is A-Test b_test c test'}
 
         new_str = compose("{a!c}", key_vals)

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -326,66 +326,66 @@ class TestParserFixedPoint:
     """Test parsing of fixed point numbers."""
 
     @pytest.mark.parametrize(
-        'test_case',
+        ('fmt', 'string', 'expected'),
         [
             # Naive
-            {'fmt': '{foo:f}', 'string': '12.34', 'expected': 12.34},
+            ('{foo:f}', '12.34', 12.34),
             # Including width and precision
-            {'fmt': '{foo:5.2f}', 'string': '12.34', 'expected': 12.34},
-            {'fmt': '{foo:5.2f}', 'string': '-1.23', 'expected': -1.23},
-            {'fmt': '{foo:5.2f}', 'string': '12.34', 'expected': 12.34},
-            {'fmt': '{foo:5.2f}', 'string': '123.45', 'expected': 123.45},
+            ('{foo:5.2f}', '12.34', 12.34),
+            ('{foo:5.2f}', '-1.23', -1.23),
+            ('{foo:5.2f}', '12.34', 12.34),
+            ('{foo:5.2f}', '123.45', 123.45),
             # Whitespace padded
-            {'fmt': '{foo:5.2f}', 'string': ' 1.23', 'expected': 1.23},
-            {'fmt': '{foo:5.2f}', 'string': ' 12.34', 'expected': 12.34},
+            ('{foo:5.2f}', ' 1.23', 1.23),
+            ('{foo:5.2f}', ' 12.34', 12.34),
             # Zero padded
-            {'fmt': '{foo:05.2f}', 'string': '01.23', 'expected': 1.23},
-            {'fmt': '{foo:05.2f}', 'string': '012.34', 'expected': 12.34},
+            ('{foo:05.2f}', '01.23', 1.23),
+            ('{foo:05.2f}', '012.34', 12.34),
             # Only precision, no width
-            {'fmt': '{foo:.2f}', 'string': '12.34', 'expected': 12.34},
+            ('{foo:.2f}', '12.34', 12.34),
             # Only width, no precision
-            {'fmt': '{foo:16f}', 'string': '            1.12', 'expected': 1.12},
+            ('{foo:16f}', '            1.12', 1.12),
             # No digits before decimal point
-            {'fmt': '{foo:3.2f}', 'string': '.12', 'expected': 0.12},
-            {'fmt': '{foo:4.2f}', 'string': '-.12', 'expected': -0.12},
-            {'fmt': '{foo:4.2f}', 'string': ' .12', 'expected': 0.12},
-            {'fmt': '{foo:4.2f}', 'string': '  .12', 'expected': 0.12},
-            {'fmt': '{foo:16f}', 'string': '             .12', 'expected': 0.12},
+            ('{foo:3.2f}', '.12', 0.12),
+            ('{foo:4.2f}', '-.12', -0.12),
+            ('{foo:4.2f}', ' .12', 0.12),
+            ('{foo:4.2f}', '  .12', 0.12),
+            ('{foo:16f}', '             .12', 0.12),
             # Exponential format
-            {'fmt': '{foo:7.2e}', 'string': '-1.23e4', 'expected': -1.23e4},
+            ('{foo:7.2e}', '-1.23e4', -1.23e4)
         ]
     )
-    def test_match(self, test_case):
+    def test_match(self, fmt, string, expected):
         """Test cases expected to be matched."""
 
         # Test parsed value
-        parsed = parse(test_case['fmt'], test_case['string'])
-        assert parsed['foo'] == test_case['expected']
+        parsed = parse(fmt, string)
+        assert parsed['foo'] == expected
 
         # Test round trip
-        composed = compose(test_case['fmt'], {'foo': test_case['expected']})
-        parsed = parse(test_case['fmt'], composed)
-        assert parsed['foo'] == test_case['expected']
+        composed = compose(fmt, {'foo': expected})
+        parsed = parse(fmt, composed)
+        assert parsed['foo'] == expected
 
     @pytest.mark.parametrize(
-        'test_case',
+        ('fmt', 'string'),
         [
             # Decimals incorrect
-            {'fmt': '{foo:5.2f}', 'string': '12345'},
-            {'fmt': '{foo:5.2f}', 'string': '1234.'},
-            {'fmt': '{foo:5.2f}', 'string': '1.234'},
-            {'fmt': '{foo:5.2f}', 'string': '123.4'},
-            {'fmt': '{foo:.2f}', 'string': '12.345'},
+            ('{foo:5.2f}', '12345'),
+            ('{foo:5.2f}', '1234.'),
+            ('{foo:5.2f}', '1.234'),
+            ('{foo:5.2f}', '123.4'),
+            ('{foo:.2f}', '12.345'),
             # Decimals correct, but width too short
-            {'fmt': '{foo:5.2f}', 'string': '1.23'},
-            {'fmt': '{foo:5.2f}', 'string': '.23'},
-            {'fmt': '{foo:10.2e}', 'string': '1.23e4'},
+            ('{foo:5.2f}', '1.23'),
+            ('{foo:5.2f}', '.23'),
+            ('{foo:10.2e}', '1.23e4'),
             # Invalid
-            {'fmt': '{foo:5.2f}', 'string': '12_34'},
-            {'fmt': '{foo:5.2f}', 'string': 'aBcD'},
+            ('{foo:5.2f}', '12_34'),
+            ('{foo:5.2f}', 'aBcD'),
         ]
     )
-    def test_no_match(self, test_case):
+    def test_no_match(self, fmt, string):
         """Test cases expected to not be matched."""
         with pytest.raises(ValueError):
-            parse(test_case['fmt'], test_case['string'])
+            parse(fmt, string)


### PR DESCRIPTION
This PR fixes the following problems with the parsing of fixed point numbers:

- Parsed value is not a float but a string
- Parsing fails if the format specifier includes width or precision (#27)

As suggested by @djhoese I added a new regular expression that is used if the format specifier includes width or precision. Finally, I updated the converter method to return floats. 

---

Examples:

1. "Naive" case without width and precision, matches any float:
```python
>>> trollsift.parse('{foo:f}', '123.456')
{'foo': 123.456}
```

2. Including width and precision:

```python
>>> trollsift.parse('{foo:5.2f}', '12.34')
{'foo': 12.34}
```

Width is considered minimum width, so that longer strings will also be matched (as long as the decimals match). This is to facilitate roundtrips with `compose`.
```python
>>> trollsift.parse('{foo:5.2f}', '1234.56')
{'foo': 1234.56}
>>> trollsift.compose('{foo:5.2f}', {'foo': 1234.56})
'1234.56'
```

The following cases will not be matched because the string is too short or the number of decimals is incorrect:
```python
>>> trollsift.parse('{foo:5.2f}', '1.23')
ValueError: String does not match pattern.
>>> trollsift.parse('{foo:5.2f}', '1.234')
ValueError: String does not match pattern.
```

3. Zero/whitespace padding is also supported
```python
>>> trollsift.parse('{foo:05.2f}', '01.23')
{'foo': 1.23}
```