### PR TITLE
Add 'allow_partial' keyword to compose

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ The following people have made contributions to this project:
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
 - [Hrobjartur Thorsteinsson (thorsteinssonh)](https://github.com/thorsteinssonh)
 - [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens)
+- [Paulo Medeiros (paulovcmedeiros)](https://github.com/paulovcmedeiros)

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -44,16 +44,20 @@ The reverse operation is called 'compose', and is equivalent to the Python
 string class format method.  Here we take the filename pattern from earlier,
 change the time stamp of the data, and write out a new file name,
 
-.. doctest::
-   :hide:
-  >>> p = Parser("/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:05d}.l1b")
-  >>> data = p.parse("/somedir/otherdir/hrpt_noaa16_20140210_1004_69022.l1b")
-
-
   >>> from datetime import datetime
-  >>> data['time'] = datetime(2012, 1, 1, 1, 1)
+  >>>
+  >>> p = Parser("/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:05d}.l1b")
+  >>> data = {'directory': 'otherdir', 'platform': 'noaa', 'platnum': '16', 'time': datetime(2012, 1, 1, 1, 1), 'orbit': 69022}
   >>> p.compose(data)
   '/somedir/otherdir/hrpt_noaa16_20120101_0101_69022.l1b'
+
+It is also possible to compose only partially, i.e., compose by specifying values
+for only a subset of the parameters in the format string. Example:
+
+  >>> p = Parser("/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:05d}.l1b")
+  >>> data = {'directory':'my_dir'}
+  >>> p.compose(data, allow_partial=True)
+  '/somedir/my_dir/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:05d}.l1b'
 
 In addition to python's builtin string formatting functionality trollsift also
 provides extra conversion options such as making all characters lowercase:

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(name="trollsift",
       keywords=["string parsing", "string formatting", "pytroll"],
       zip_safe=False,
       install_requires=[],
-      tests_require=['pytest']
+      tests_require=['pytest', 'parameterized']
       )

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(name="trollsift",
       keywords=["string parsing", "string formatting", "pytroll"],
       zip_safe=False,
       install_requires=[],
-      tests_require=['pytest', 'parameterized']
+      tests_require=['pytest']
       )

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -46,11 +46,16 @@ class Parser(object):
         return compose(self.fmt, keyvals)
 
     def partial_compose(self, keyvals):
-        '''Return string composed according to *fmt* string and filled
-        with values with the corresponding keys in *keyvals* dictionary.
-        Not all params in *fmt* need to be specified in *keyvals*.
-        Unspecified parameters are left unchanged.
-        '''
+        """Convert parameters in `keyvals` to a string based on the *fmt* string.
+
+        This method is similar to compose, but accepts partial composing, i.e.,
+        not all parameters in `fmt` need to be specified in `keyvals`. Unspecified
+        parameters are left unchanged.
+
+        Args:
+            keyvals (dict): "Parameter --> parameter value" map
+
+        """
         return partial_compose(self.fmt, keyvals)
 
     format = compose

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -460,6 +460,7 @@ def compose(fmt, keyvals):
     """Convert parameters in `keyvals` to a string based on `fmt` string."""
     return formatter.format(fmt, **keyvals)
 
+
 def partial_compose(fmt, keyvals):
     """Convert parameters in `keyvals` to a string based on `fmt` string.
 
@@ -478,6 +479,7 @@ def partial_compose(fmt, keyvals):
         composed_string = composed_string.replace(fmt_placeholder, fmt_specification)
 
     return composed_string
+
 
 def _replace_undefined_params_with_placeholders(fmt, keyvals=None):
     """Replace with placeholders params in `fmt` not specified in `keyvals`."""

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -2,9 +2,12 @@ import unittest
 import datetime as dt
 import pytest
 
+from parameterized import parameterized
+
 from trollsift.parser import get_convert_dict, regex_formatter
 from trollsift.parser import _convert
 from trollsift.parser import parse, globify, validate, is_one2one, compose
+from trollsift.parser import partial_compose, _replace_undefined_params_with_placeholders
 
 
 class TestParser(unittest.TestCase):
@@ -272,33 +275,66 @@ class TestParser(unittest.TestCase):
         self.assertFalse(is_one2one(
             "/somedir/{directory}/somedata_{platform:4s}_{time:%Y%d%m-%H%M}_{orbit:d}.l1b"))
 
-    def test_compose(self):
+    @parameterized.expand([[compose], [partial_compose]])
+    def test_compose(self, compose_function):
         """Test the compose method's custom conversion options."""
         key_vals = {'a': 'this Is A-Test b_test c test'}
 
-        new_str = compose("{a!c}", key_vals)
+        new_str = compose_function("{a!c}", key_vals)
         self.assertEqual(new_str, 'This is a-test b_test c test')
-        new_str = compose("{a!h}", key_vals)
+        new_str = compose_function("{a!h}", key_vals)
         self.assertEqual(new_str, 'thisisatestbtestctest')
-        new_str = compose("{a!H}", key_vals)
+        new_str = compose_function("{a!H}", key_vals)
         self.assertEqual(new_str, 'THISISATESTBTESTCTEST')
-        new_str = compose("{a!l}", key_vals)
+        new_str = compose_function("{a!l}", key_vals)
         self.assertEqual(new_str, 'this is a-test b_test c test')
-        new_str = compose("{a!R}", key_vals)
+        new_str = compose_function("{a!R}", key_vals)
         self.assertEqual(new_str, 'thisIsATestbtestctest')
-        new_str = compose("{a!t}", key_vals)
+        new_str = compose_function("{a!t}", key_vals)
         self.assertEqual(new_str, 'This Is A-Test B_Test C Test')
-        new_str = compose("{a!u}", key_vals)
+        new_str = compose_function("{a!u}", key_vals)
         self.assertEqual(new_str, 'THIS IS A-TEST B_TEST C TEST')
         # builtin repr
-        new_str = compose("{a!r}", key_vals)
+        new_str = compose_function("{a!r}", key_vals)
         self.assertEqual(new_str, '\'this Is A-Test b_test c test\'')
         # no formatting
-        new_str = compose("{a}", key_vals)
+        new_str = compose_function("{a}", key_vals)
         self.assertEqual(new_str, 'this Is A-Test b_test c test')
         # bad formatter
-        self.assertRaises(ValueError, compose, "{a!X}", key_vals)
+        self.assertRaises(ValueError, compose_function, "{a!X}", key_vals)
         self.assertEqual(new_str, 'this Is A-Test b_test c test')
+
+    def test_replace_undefined_params_with_placeholders(self):
+        """Test replace_undefined_params_with_placeholders function."""
+        original_fmt = "{foo}/{bar}/{baz:%Y}/{baz:%Y%m%d_%H%M}/{baz:%Y}/{bar:d}"
+        keyvals = {"foo": "foo", "bar": 0}
+
+        new_fmt, placeholders_dict = _replace_undefined_params_with_placeholders(
+            fmt=original_fmt, keyvals=keyvals
+        )
+        baz_1 = hex(hash("{baz:%Y}"))
+        baz_2 = hex(hash("{baz:%Y%m%d_%H%M}"))
+        expected_new_fmt = "{foo}/{bar}/" + f"({baz_1})/({baz_2})/({baz_1})/" + "{bar:d}"
+        self.assertEqual(new_fmt, expected_new_fmt)
+
+        recovered_fmt = new_fmt
+        for placeholder, value in placeholders_dict.items():
+            recovered_fmt = recovered_fmt.replace(placeholder, value)
+        self.assertEqual(recovered_fmt, original_fmt)
+
+    def test_partial_compose_simple(self):
+        """Test partial_compose with a simple use case."""
+        fmt = "{variant:s}/{platform_name}_{start_time:%Y%m%d_%H%M}_{product}.{format}"
+        composed = partial_compose(
+            fmt=fmt, keyvals={"platform_name": "foo", "format": "bar"}
+        )
+        self.assertEqual(composed, "{variant:s}/foo_{start_time:%Y%m%d_%H%M}_{product}.bar")
+
+    def test_partial_compose_repeated_vars_with_different_formatting(self):
+        """Test partial_compose with a fmt with repeated vars with different_formatting."""
+        fmt = "/foo/{start_time:%Y%m}/bar/{baz}_{start_time:%Y%m%d_%H%M}.{format}"
+        composed = partial_compose(fmt=fmt, keyvals={"format": "qux"})
+        self.assertEqual(composed, "/foo/{start_time:%Y%m}/bar/{baz}_{start_time:%Y%m%d_%H%M}.qux")
 
     def test_greediness(self):
         """Test that the minimum match is parsed out.
@@ -325,6 +361,7 @@ class TestParser(unittest.TestCase):
 class TestParserFixedPoint:
     """Test parsing of fixed point numbers."""
 
+    @pytest.mark.parametrize('compose_function', [compose, partial_compose])
     @pytest.mark.parametrize(
         ('fmt', 'string', 'expected'),
         [
@@ -355,7 +392,7 @@ class TestParserFixedPoint:
             ('{foo:7.2e}', '-1.23e4', -1.23e4)
         ]
     )
-    def test_match(self, fmt, string, expected):
+    def test_match(self, compose_function, fmt, string, expected):
         """Test cases expected to be matched."""
 
         # Test parsed value
@@ -363,7 +400,7 @@ class TestParserFixedPoint:
         assert parsed['foo'] == expected
 
         # Test round trip
-        composed = compose(fmt, {'foo': expected})
+        composed = compose_function(fmt, {'foo': expected})
         parsed = parse(fmt, composed)
         assert parsed['foo'] == expected
 

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -331,7 +331,7 @@ class TestCompose:
         """Make sure the default compose call does not accept partial composition."""
         fmt = "{foo}_{bar}.qux"
         with pytest.raises(KeyError):
-            _ = compose(fmt, {"foo":"foo"})
+            _ = compose(fmt, {"foo": "foo"})
 
     def test_partial_compose_simple(self):
         """Test partial compose with a simple use case."""
@@ -346,7 +346,7 @@ class TestCompose:
     def test_partial_compose_with_similarly_named_params(self):
         """Test that partial compose handles well vars with common substrings in name."""
         original_fmt = "{foo}{afooo}{fooo}.{bar}/{baz:%Y}/{baz:%Y%m%d_%H}/{baz:%Y}/{bar:d}"
-        composed = compose(fmt=original_fmt, keyvals={"afooo":"qux"}, allow_partial=True)
+        composed = compose(fmt=original_fmt, keyvals={"afooo": "qux"}, allow_partial=True)
         assert composed == "{foo}qux{fooo}.{bar}/{baz:%Y}/{baz:%Y%m%d_%H}/{baz:%Y}/{bar:d}"
 
     def test_partial_compose_repeated_vars_with_different_formatting(self):


### PR DESCRIPTION
This implements a `partial_compose` method that works similarly to the existing `compose` except that, if any parameters present in `fmt` are left unspecified in `keyvals`, then these unspecified parameters are left untouched, while the others are composed as usual.

It has been useful to me in a project I'm currently working. Hopefully it'll be useful for other trollsift users as well.