### PR TITLE
Fix problems with type='' in string padding syntax

### DIFF
--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -163,13 +163,14 @@ spec_regexes['e'] = spec_regexes['f']
 spec_regexes['E'] = spec_regexes['f']
 spec_regexes['g'] = spec_regexes['f']
 spec_regexes['X'] = spec_regexes['x']
-allow_multiple = ['c', 'd', 'o', 's', 'x', 'X']
+spec_regexes[''] = spec_regexes['s']
+allow_multiple = ['c', 'd', 'o', 's', '', 'x', 'X']
 fixed_point_types = ['f', 'e', 'E', 'g']
 # format_spec ::=  [[fill]align][sign][#][0][width][,][.precision][type]
 # https://docs.python.org/3.4/library/string.html#format-specification-mini-language
 fmt_spec_regex = re.compile(
     r'(?P<align>(?P<fill>.)?[<>=^])?(?P<sign>[\+\-\s])?(?P<pound>#)?(?P<zero>0)?(?P<width>\d+)?'
-    r'(?P<comma>,)?(?P<precision>.\d+)?(?P<type>[bcdeEfFgGnosxX%])')
+    r'(?P<comma>,)?(?P<precision>.\d+)?(?P<type>[bcdeEfFgGnosxX%]?)')
 
 
 def _get_fixed_point_regex(regex_dict, width, precision):
@@ -294,7 +295,7 @@ class RegexFormatter(string.Formatter):
         if fill is None:
             if width is not None and width[0] == '0':
                 fill = '0'
-            elif ftype in ['s', 'd']:
+            elif ftype in ['s', '', 'd']:
                 fill = ' '
 
         char_type = spec_regexes[ftype]
@@ -304,7 +305,7 @@ class RegexFormatter(string.Formatter):
                 width=width,
                 precision=precision
             )
-        if ftype == 's' and align and align.endswith('='):
+        if ftype in ['s', ''] and align and align.endswith('='):
             raise ValueError("Invalid format specification: '{}'".format(format_spec))
         final_regex = char_type
         if ftype in allow_multiple and (not width or width == '0'):
@@ -390,7 +391,7 @@ def _convert(convdef, stri):
     is_fixed_point = any([ftype in convdef for ftype in fixed_point_types])
     if '%' in convdef:
         result = dt.datetime.strptime(stri, convdef)
-    elif 'd' in convdef or 's' in convdef or is_fixed_point:
+    elif 'd' in convdef or 's' in convdef or '' in convdef or is_fixed_point:
         stri = _strip_padding(convdef, stri)
         if 'd' in convdef:
             result = int(stri)

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -305,7 +305,7 @@ class RegexFormatter(string.Formatter):
                 width=width,
                 precision=precision
             )
-        if ftype in ['s', ''] and align and align.endswith('='):
+        if ftype in ('s', '') and align and align.endswith('='):
             raise ValueError("Invalid format specification: '{}'".format(format_spec))
         final_regex = char_type
         if ftype in allow_multiple and (not width or width == '0'):

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -388,19 +388,15 @@ def _get_number_from_fmt(fmt):
 
 def _convert(convdef, stri):
     """Convert the string *stri* to the given conversion definition *convdef*."""
-    is_fixed_point = any([ftype in convdef for ftype in fixed_point_types])
     if '%' in convdef:
         result = dt.datetime.strptime(stri, convdef)
-    elif 'd' in convdef or 's' in convdef or '' in convdef or is_fixed_point:
-        stri = _strip_padding(convdef, stri)
-        if 'd' in convdef:
-            result = int(stri)
-        elif is_fixed_point:
-            result = float(stri)
-        else:
-            result = stri
     else:
-        result = stri
+        result = _strip_padding(convdef, stri)
+        if 'd' in convdef:
+            result = int(result)
+        elif any(float_type_marker in convdef for float_type_marker in fixed_point_types):
+            result = float(result)
+
     return result
 
 

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -126,6 +126,19 @@ class TestParser(unittest.TestCase):
                                       'time': dt.datetime(2014, 2, 12, 14, 12),
                                       'orbit': 12345})
 
+    def test_parse_string_padding_syntax_with_and_without_s(self):
+        """Test that, in string padding syntax, '' is equivalent to 's'.
+
+        From <https://docs.python.org/3.4/library/string.html#format-specification-mini-language>:
+            * Type 's': String format. This is the default type for strings and may be omitted.
+            * Type None: The same as 's'.
+        """
+        result = parse('{foo}/{bar:_<8}', 'baz/qux_____')
+        expected_result = parse('{foo}/{bar:_<8s}', 'baz/qux_____')
+        self.assertEqual(expected_result["foo"], "baz")
+        self.assertEqual(expected_result["bar"], "qux")
+        self.assertEqual(result, expected_result)
+
     def test_parse_wildcards(self):
         # Run
         result = parse(


### PR DESCRIPTION
Hello again,

I believe this fixes #30. According to <https://docs.python.org/3.4/library/string.html#format-specification-mini-language>, type `'s'` may be omitted, and, even more explicitly, type `None` is equivalent to type `s`. This PR changes the code to that effect.

Just to make it easy to see what is going on in the change I made to the `fmt_spec_regex` variable, I only added an `?` after `[bcdeEfFgGnosxX%]`. The other changes in the code should be easy to see in the diff.

Cheers :)