### PR TITLE
Replace global RegexFormatter with memoized function

### DIFF
--- a/trollsift/tests/integrationtests/test_parser.py
+++ b/trollsift/tests/integrationtests/test_parser.py
@@ -42,15 +42,14 @@ class TestParser(unittest.TestCase):
 
     def test_cache_clear(self):
         """Test we can clear the internal cache properly"""
-        from trollsift.parser import purge
-        from trollsift.parser import regex_formatter
+        from trollsift.parser import purge, regex_format
         # Run
         result = self.p.parse(self.string)
         # Assert
         self.assertDictEqual(result, self.data)
-        assert regex_formatter.format.cache_info()[-1] != 0
+        assert regex_format.cache_info()[-1] != 0
         purge()
-        assert regex_formatter.format.cache_info()[-1] == 0
+        assert regex_format.cache_info()[-1] == 0
 
     def test_compose(self):
         # Run

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -2,7 +2,7 @@ import unittest
 import datetime as dt
 import pytest
 
-from trollsift.parser import get_convert_dict, regex_formatter
+from trollsift.parser import get_convert_dict, extract_values
 from trollsift.parser import _convert
 from trollsift.parser import parse, globify, validate, is_one2one, compose
 
@@ -31,54 +31,54 @@ class TestParser(unittest.TestCase):
 
     def test_extract_values(self):
         fmt = "/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:d}.l1b"
-        result = regex_formatter.extract_values(fmt, self.string)
+        result = extract_values(fmt, self.string)
         self.assertDictEqual(result, {'directory': 'otherdir',
                                       'platform': 'noaa', 'platnum': '16',
                                       'time': '20140210_1004', 'orbit': '69022'})
 
     def test_extract_values_end(self):
         fmt = "/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:d}"
-        result = regex_formatter.extract_values(fmt, self.string3)
+        result = extract_values(fmt, self.string3)
         self.assertDictEqual(result, {'directory': 'otherdir',
                                       'platform': 'noaa', 'platnum': '16',
                                       'time': '20140210_1004', 'orbit': '69022'})
 
     def test_extract_values_beginning(self):
         fmt = "{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:d}"
-        result = regex_formatter.extract_values(fmt, self.string4)
+        result = extract_values(fmt, self.string4)
         self.assertDictEqual(result, {'directory': '/somedir/otherdir',
                                       'platform': 'noaa', 'platnum': '16',
                                       'time': '20140210_1004', 'orbit': '69022'})
 
     def test_extract_values_s4spair(self):
         fmt = "{directory}/hrpt_{platform:4s}{platnum:s}_{time:%Y%m%d_%H%M}_{orbit:d}"
-        result = regex_formatter.extract_values(fmt, self.string4)
+        result = extract_values(fmt, self.string4)
         self.assertDictEqual(result, {'directory': '/somedir/otherdir',
                                       'platform': 'noaa', 'platnum': '16',
                                       'time': '20140210_1004', 'orbit': '69022'})
 
     def test_extract_values_ss2pair(self):
         fmt = "{directory}/hrpt_{platform:s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:d}"
-        result = regex_formatter.extract_values(fmt, self.string4)
+        result = extract_values(fmt, self.string4)
         self.assertDictEqual(result, {'directory': '/somedir/otherdir',
                                       'platform': 'noaa', 'platnum': '16',
                                       'time': '20140210_1004', 'orbit': '69022'})
 
     def test_extract_values_ss2pair_end(self):
         fmt = "{directory}/hrpt_{platform:s}{platnum:2s}"
-        result = regex_formatter.extract_values(fmt, "/somedir/otherdir/hrpt_noaa16")
+        result = extract_values(fmt, "/somedir/otherdir/hrpt_noaa16")
         self.assertDictEqual(result, {'directory': '/somedir/otherdir',
                                       'platform': 'noaa', 'platnum': '16'})
 
     def test_extract_values_sdatetimepair_end(self):
         fmt = "{directory}/hrpt_{platform:s}{date:%Y%m%d}"
-        result = regex_formatter.extract_values(fmt, "/somedir/otherdir/hrpt_noaa20140212")
+        result = extract_values(fmt, "/somedir/otherdir/hrpt_noaa20140212")
         self.assertDictEqual(result, {'directory': '/somedir/otherdir',
                                       'platform': 'noaa', 'date': '20140212'})
 
     def test_extract_values_everything(self):
         fmt = "{everything}"
-        result = regex_formatter.extract_values(fmt, self.string)
+        result = extract_values(fmt, self.string)
         self.assertDictEqual(
             result, {'everything': '/somedir/otherdir/hrpt_noaa16_20140210_1004_69022.l1b'})
 
@@ -88,7 +88,7 @@ class TestParser(unittest.TestCase):
         #             {'platform': '4s'}, {'platnum': '2s'},
         #             '_', {'time': '%Y%m%d_%H%M'}, '_',
         #             {'orbit': '0>5d'}, '.l1b']
-        result = regex_formatter.extract_values(fmt, self.string2)
+        result = extract_values(fmt, self.string2)
         # Assert
         self.assertDictEqual(result, {'directory': 'otherdir',
                                       'platform': 'noaa', 'platnum': '16',
@@ -96,15 +96,15 @@ class TestParser(unittest.TestCase):
 
     def test_extract_values_fails(self):
         fmt = '/somedir/{directory}/hrpt_{platform:4s}{platnum:2s}_{time:%Y%m%d_%H%M}_{orbit:4d}.l1b'
-        self.assertRaises(ValueError, regex_formatter.extract_values, fmt, self.string)
+        self.assertRaises(ValueError, extract_values, fmt, self.string)
 
     def test_extract_values_full_match(self):
         """Test that a string must completely match."""
         fmt = '{orbit:05d}'
-        val = regex_formatter.extract_values(fmt, '12345')
+        val = extract_values(fmt, '12345')
         self.assertEqual(val, {'orbit': '12345'})
-        self.assertRaises(ValueError, regex_formatter.extract_values, fmt, '12345abc')
-        val = regex_formatter.extract_values(fmt, '12345abc', full_match=False)
+        self.assertRaises(ValueError, extract_values, fmt, '12345abc')
+        val = extract_values(fmt, '12345abc', full_match=False)
         self.assertEqual(val, {'orbit': '12345'})
 
     def test_convert_digits(self):


### PR DESCRIPTION
Resolves #37 

Previously a shared global instance of `RegexFormatter` was used in `parse` when invoking `extract_values`. This had the effect that running `parse` in many threads could result in concurrent writes to `RegexFormatter`s `_cached_field` dictionary.  These changes introduce a method `regex_format`, which constructs a new instance of `RegexFormatter` before running `format`, making each call to `format` thread-safe. The result of this call is still backed by an `lru_cache` for performance purposes. 