### PR TITLE
Add keys method to Parser class

### DIFF
--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -34,7 +34,7 @@ class Parser(object):
         return self.fmt
 
     def keys(self):
-        """Return the keys defined in the format"""
+        """Get parameter names defined in the format string."""
         convert_dict = get_convert_dict(self.fmt)
         return convert_dict.keys()
 

--- a/trollsift/parser.py
+++ b/trollsift/parser.py
@@ -33,6 +33,11 @@ class Parser(object):
     def __str__(self):
         return self.fmt
 
+    def keys(self):
+        """Return the keys defined in the format"""
+        convert_dict = get_convert_dict(self.fmt)
+        return convert_dict.keys()
+
     def parse(self, stri, full_match=True):
         '''Parse keys and corresponding values from *stri* using format
         described in *fmt* string.

--- a/trollsift/tests/unittests/test_parser.py
+++ b/trollsift/tests/unittests/test_parser.py
@@ -4,7 +4,7 @@ import pytest
 
 from trollsift.parser import get_convert_dict, extract_values
 from trollsift.parser import _convert
-from trollsift.parser import parse, globify, validate, is_one2one, compose
+from trollsift.parser import parse, globify, validate, is_one2one, compose, Parser
 
 
 class TestParser(unittest.TestCase):
@@ -16,6 +16,12 @@ class TestParser(unittest.TestCase):
         self.string2 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_00022.l1b"
         self.string3 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_69022"
         self.string4 = "/somedir/otherdir/hrpt_noaa16_20140210_1004_69022"
+
+    def test_parser_keys(self):
+        parser = Parser(self.fmt)
+        keys = {"directory", "platform", "platnum", "time", "orbit"}
+        self.assertTrue(keys.issubset(parser.keys())
+                        and keys.issuperset(parser.keys()))
 
     def test_get_convert_dict(self):
         # Run


### PR DESCRIPTION
This PR closes #45 by adding a keys method to the `parser.Parser` class.