### PR TITLE
Update CI to use Python 3.10 - 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
Update CI to use Python versions 3.10, 3.11 and 3.12.
