### PR TITLE
Drop support for Python 3.8 and below

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 keywords = ["string parsing", "string formatting", "pytroll"]
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 dependencies = []
 dynamic = ["version"]
 


### PR DESCRIPTION
Hatchling (our build system) only supports Python 3.8+ and other pytroll packages have dropped Python 3.8 and some even 3.9 support.